### PR TITLE
Instrumenting dappbot-cli w/ analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -496,6 +496,15 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -510,6 +519,11 @@
 			"requires": {
 				"defer-to-connect": "^1.0.1"
 			}
+		},
+		"@types/analytics-node": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.1.tgz",
+			"integrity": "sha512-+Jrl6aQIV2uSy60DBSXflPt3+nTf/IxTVDM1gw5PhPhFi/STPDUlyiUp+zrmcEiiLQ7Y2R4jhrcQ6BcqAOclzg=="
 		},
 		"@types/axios": {
 			"version": "0.14.0",
@@ -699,6 +713,37 @@
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"analytics-node": {
+			"version": "3.4.0-beta.1",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+			"requires": {
+				"@segment/loosely-validate-event": "^2.0.0",
+				"axios": "^0.18.1",
+				"axios-retry": "^3.0.2",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.2.1",
+				"ms": "^2.0.0",
+				"remove-trailing-slash": "^0.1.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"axios": {
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+					"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+					"requires": {
+						"follow-redirects": "1.5.10",
+						"is-buffer": "^2.0.2"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
 			}
 		},
 		"ansi-align": {
@@ -1235,6 +1280,14 @@
 				}
 			}
 		},
+		"axios-retry": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
+			"integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
+			"requires": {
+				"is-retry-allowed": "^1.1.0"
+			}
+		},
 		"babel-plugin-dynamic-import-node": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -1650,6 +1703,11 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
 		"chokidar": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
@@ -1910,6 +1968,11 @@
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
 		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2072,6 +2135,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"crypto-random-string": {
 			"version": "1.0.0",
@@ -4369,8 +4437,7 @@
 		"is-retry-allowed": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-			"dev": true
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -4451,6 +4518,11 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"join-component": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -4664,6 +4736,11 @@
 			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
 			"dev": true
 		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -4824,6 +4901,16 @@
 				"escape-string-regexp": "^2.0.0"
 			}
 		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			}
+		},
 		"md5-hex": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
@@ -4976,8 +5063,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"multimatch": {
 			"version": "3.0.0",
@@ -6056,6 +6142,11 @@
 			"requires": {
 				"es6-error": "^4.0.1"
 			}
+		},
+		"remove-trailing-slash": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"repeat-element": {
 			"version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -431,21 +431,44 @@
 			}
 		},
 		"@eximchain/dappbot-api-client": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-api-client/-/dappbot-api-client-1.1.0.tgz",
-			"integrity": "sha512-E8ZUFv57ACGgsr3QaB8FfCFxWt6fJc0lLley1vmiQgzmfO2GUrLr3o6mzwHBI4AzCuZQDyc9T/2QZfTi28tdCg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-api-client/-/dappbot-api-client-1.2.1.tgz",
+			"integrity": "sha512-t09oRNk3aXQTXazFO8nj/nkaLoKs+DELwL3p16UY6/NFxjT8PzDgjb4jAZTz9dd3kGQxE0/7AAelwv4hTCfUDA==",
 			"requires": {
-				"@eximchain/dappbot-types": "^1.2.4",
+				"@eximchain/dappbot-types": "^1.7.4",
 				"@types/axios": "^0.14.0",
 				"@types/lodash.omit": "^4.5.6",
+				"@types/node": "^12.7.10",
 				"@types/node-fetch": "^2.5.0",
 				"@types/react": "^16.9.2",
 				"@types/request-promise-native": "^1.0.16",
 				"ethereum-types": "^2.1.2",
 				"lodash.omit": "^4.5.0",
+				"node-fetch": "^2.6.0",
+				"password-validator": "^5.0.2",
 				"react-request-hook": "^2.1.1",
+				"request": "^2.88.0",
 				"request-promise-native": "^1.0.7",
 				"typescript": "^3.5.2"
+			},
+			"dependencies": {
+				"@eximchain/dappbot-types": {
+					"version": "1.7.4",
+					"resolved": "https://registry.npmjs.org/@eximchain/dappbot-types/-/dappbot-types-1.7.4.tgz",
+					"integrity": "sha512-rM9OyKvaCSyqbcmfW/InG4ROpu611/VDDRlFE5pDf0lyPDodGZ5JbN7p0EUQYfRmPSNVILeOWJ51p8aeOyrzKA==",
+					"requires": {
+						"@types/lodash.groupby": "^4.6.6",
+						"@types/stripe": "6.31.25",
+						"lodash.groupby": "^4.6.0",
+						"ts-xor": "^1.0.8",
+						"typescript": "^3.6.2"
+					}
+				},
+				"@types/node": {
+					"version": "12.7.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
+					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+				}
 			}
 		},
 		"@eximchain/dappbot-types": {
@@ -617,9 +640,9 @@
 			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
 		},
 		"@types/node-fetch": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.0.tgz",
-			"integrity": "sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
+			"integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -650,9 +673,9 @@
 			}
 		},
 		"@types/request-promise-native": {
-			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.16.tgz",
-			"integrity": "sha512-gbLf6cg1XGBU8BObOgs5VkCQo5JFz2GstgZjyE4FRbig/jiCEdiynu2fCzJlw3qYPuoj59spKnvuRLN4PsMvhA==",
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.17.tgz",
+			"integrity": "sha512-05/d0WbmuwjtGMYEdHIBZ0tqMJJQ2AD9LG2F6rKNBGX1SSFR27XveajH//2N/XYtual8T9Axwl+4v7oBtPUZqg==",
 			"requires": {
 				"@types/request": "*"
 			}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"postinstall": "node build/cli.js onboarding"
 	},
 	"dependencies": {
-		"@eximchain/dappbot-api-client": "^1.1.0",
+		"@eximchain/dappbot-api-client": "^1.2.1",
 		"@eximchain/dappbot-types": "^1.6.1",
 		"@types/analytics-node": "^3.1.1",
 		"@types/ink-spinner": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"dappbot": "build/cli.js"
 	},
 	"repository": {
-		"type" : "git",
-		"url" : "https://github.com/Eximchain/dappbot-cli"
+		"type": "git",
+		"url": "https://github.com/Eximchain/dappbot-cli"
 	},
 	"engines": {
 		"node": ">=8"
@@ -27,12 +27,14 @@
 	"dependencies": {
 		"@eximchain/dappbot-api-client": "^1.1.0",
 		"@eximchain/dappbot-types": "^1.6.1",
+		"@types/analytics-node": "^3.1.1",
 		"@types/ink-spinner": "^2.0.1",
 		"@types/lodash.flatten": "^4.4.6",
 		"@types/lodash.groupby": "^4.6.6",
 		"@types/node": "^12.7.5",
 		"@types/shelljs": "^0.8.5",
 		"@types/yargs": "^13.0.2",
+		"analytics-node": "^3.4.0-beta.1",
 		"axios": "^0.19.0",
 		"completarr": "^0.2.2",
 		"ethereum-types": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"author": {
 		"name": "John O'Sullivan",
 		"email": "john@eximchain.com"

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { loadFileFromPath, addDefaultAuthIfPresent, addDefaultConfigIfPresent } from './services/util';
 
-const npmPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './../package.json')).toString());
+export const npmPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './../package.json')).toString());
 
 export const DEFAULT_CONFIG_PATH = './dappbotConfig.json';
 export const DEFAULT_DATA_PATH = './dappbotAuthData.json';

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,7 +2,7 @@
 import yargs, { Arguments } from 'yargs';
 import fs from 'fs';
 import path from 'path';
-import { loadFileFromPath, addDefaultAuthIfPresent, addDefaultConfigIfPresent } from './services/util';
+import { loadFileFromPath, addDefaultAuthIfPresent, addDefaultConfigIfPresent } from './services';
 
 export const npmPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './../package.json')).toString());
 

--- a/src/rootCmds/authCmds/beginPassReset.tsx
+++ b/src/rootCmds/authCmds/beginPassReset.tsx
@@ -26,7 +26,7 @@ export function handler(args: ArgShape<BeginPassReset.Args>) {
       return (
         <PrettyRequest 
           operation={ApiMethodLabel(BeginPassReset.HTTP, BeginPassReset.Path)}
-          req={() => API.auth.beginPasswordReset.resource({ username })} />
+          resource={() => API.auth.beginPasswordReset.resource({ username })} />
       )
     }
   }

--- a/src/rootCmds/authCmds/beginPassReset.tsx
+++ b/src/rootCmds/authCmds/beginPassReset.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
 import { PrettyRequest, App, ApiMethodLabel,  } from '../../ui';
-import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services/util';
+import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services';
 import { ArgShape } from '../../cli';
 import { BeginPassReset } from '@eximchain/dappbot-types/spec/methods/auth';
 

--- a/src/rootCmds/authCmds/confirmPassReset.tsx
+++ b/src/rootCmds/authCmds/confirmPassReset.tsx
@@ -28,7 +28,7 @@ export function handler(args: ArgShape<ConfirmPassReset.Args>) {
       return (
         <PrettyRequest
           operation={ApiMethodLabel(ConfirmPassReset.HTTP, ConfirmPassReset.Path)} 
-          req={() => API.auth.confirmPasswordReset.resource({
+          resource={() => API.auth.confirmPasswordReset.resource({
             username, newPassword, passwordResetCode
           })} />
       )

--- a/src/rootCmds/authCmds/confirmPassReset.tsx
+++ b/src/rootCmds/authCmds/confirmPassReset.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
 import { PrettyRequest, App, ApiMethodLabel } from '../../ui';
-import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services/util';
+import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services';
 import { ArgShape } from '../../cli';
 import { ConfirmPassReset } from '@eximchain/dappbot-types/spec/methods/auth';
 

--- a/src/rootCmds/authCmds/login.tsx
+++ b/src/rootCmds/authCmds/login.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { PrettyRequest, App, ApiMethodLabel } from '../../ui';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services/util';
+import { commandFromSampleArgs, describePositionalArgs, fastRender } from '../../services';
 import { ArgShape } from '../../cli';
 import { Login } from '@eximchain/dappbot-types/spec/methods/auth';
 

--- a/src/rootCmds/authCmds/login.tsx
+++ b/src/rootCmds/authCmds/login.tsx
@@ -23,7 +23,7 @@ export function handler(args: ArgShape<Login.Args>) {
       return (
         <PrettyRequest
           operation={ApiMethodLabel(Login.HTTP, Login.Path)}
-          req={() => API.auth.login.resource({
+          resource={() => API.auth.login.resource({
             username, password
           })} />
       )

--- a/src/rootCmds/authCmds/refresh.tsx
+++ b/src/rootCmds/authCmds/refresh.tsx
@@ -27,7 +27,7 @@ export function handler(args: ArgShape<Refresh.Args>) {
       return (
         <PrettyRequest 
           operation={ApiMethodLabel(Refresh.HTTP, Refresh.Path)}
-          req={() => API.auth.refresh.resource({ refreshToken })} />
+          resource={() => API.auth.refresh.resource({ refreshToken })} />
       )
     }
   }

--- a/src/rootCmds/authCmds/refresh.tsx
+++ b/src/rootCmds/authCmds/refresh.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { render } from 'ink';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { commandFromSampleArgs, describePositionalArgs } from '../../services/util';
+import { commandFromSampleArgs, describePositionalArgs } from '../../services';
 import { PrettyRequest, App, ApiMethodLabel } from '../../ui';
 import { ArgShape } from '../../cli';
 import { Refresh } from '@eximchain/dappbot-types/spec/methods/auth';

--- a/src/rootCmds/privateCmds/createDapp.tsx
+++ b/src/rootCmds/privateCmds/createDapp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Argv, Options } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender, cleanExit, analytics, standardTrackProps } from '../../services/util';
+import { requireAuthData, fastRender, analytics, standardTrackProps } from '../../services';
 import { ArgShape, DappNameArg, UniversalArgs } from '../../cli';
 import { CreateDapp } from '@eximchain/dappbot-types/spec/methods/private';
 import { App, PrettyRequest, ApiMethodLabel, ErrorBox } from '../../ui';

--- a/src/rootCmds/privateCmds/createDapp.tsx
+++ b/src/rootCmds/privateCmds/createDapp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Argv, Options } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender, cleanExit } from '../../services/util';
+import { requireAuthData, fastRender, cleanExit, analytics, standardTrackProps } from '../../services/util';
 import { ArgShape, DappNameArg, UniversalArgs } from '../../cli';
 import { CreateDapp } from '@eximchain/dappbot-types/spec/methods/private';
 import { App, PrettyRequest, ApiMethodLabel, ErrorBox } from '../../ui';
@@ -65,13 +65,21 @@ export function handler(args: ArgShape<CreateDapp.Args & DappNameArg>) {
   }
   const Abi = args.AbiFile;
   // TODO: Validate Abi, just for sanity's sake
+
+  const createArgs = { Web3URL, GuardianURL, ContractAddr, Tier, Abi };
   fastRender(
     <App args={args} renderFunc={({ API }) => {
       return (
         <PrettyRequest
           operation={ApiMethodLabel(CreateDapp.HTTP, CreateDapp.Path(DappName))}
-          req={() => API.private.createDapp.resource(DappName, {
-            Web3URL, GuardianURL, ContractAddr, Tier, Abi
+          resource={() => API.private.createDapp.resource(DappName, createArgs)} 
+          onSuccess={() => analytics.track({
+            event: 'Dapp Created - CLI',
+            userId: API.authData.User.Email,
+            properties: {
+              ...standardTrackProps(API),
+              DappName, ...createArgs
+            }
           })} />
       )
     }} />

--- a/src/rootCmds/privateCmds/deleteDapp.tsx
+++ b/src/rootCmds/privateCmds/deleteDapp.tsx
@@ -3,7 +3,7 @@ import { Argv } from 'yargs';
 import { App, PrettyRequest, ApiMethodLabel } from '../../ui';
 import { ArgShape, DappNameArg, UniversalArgs } from '../../cli';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender } from '../../services/util';
+import { requireAuthData, fastRender, analytics, standardTrackProps } from '../../services/util';
 import { DeleteDapp } from '@eximchain/dappbot-types/spec/methods/private';
 
 export const command = `${RootResources.private}/deleteDapp <DappName>`;
@@ -21,7 +21,15 @@ export function handler(args:ArgShape<DappNameArg>) {
       return (
         <PrettyRequest 
           operation={ApiMethodLabel(DeleteDapp.HTTP, DeleteDapp.Path(DappName))}
-          req={() => API.private.deleteDapp.resource(DappName)} />
+          resource={() => API.private.deleteDapp.resource(DappName)} 
+          onSuccess={() => analytics.track({
+            event: 'Dapp Deleted - CLI',
+            userId: API.authData.User.Email,
+            properties: {
+              ...standardTrackProps(API),
+              DappName
+            }
+          })} />
       )
     }} />
   )

--- a/src/rootCmds/privateCmds/deleteDapp.tsx
+++ b/src/rootCmds/privateCmds/deleteDapp.tsx
@@ -3,7 +3,7 @@ import { Argv } from 'yargs';
 import { App, PrettyRequest, ApiMethodLabel } from '../../ui';
 import { ArgShape, DappNameArg, UniversalArgs } from '../../cli';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender, analytics, standardTrackProps } from '../../services/util';
+import { requireAuthData, fastRender, analytics, standardTrackProps } from '../../services';
 import { DeleteDapp } from '@eximchain/dappbot-types/spec/methods/private';
 
 export const command = `${RootResources.private}/deleteDapp <DappName>`;

--- a/src/rootCmds/privateCmds/listDapps.tsx
+++ b/src/rootCmds/privateCmds/listDapps.tsx
@@ -20,7 +20,7 @@ export function handler(args: ArgShape) {
       return (
         <PrettyRequest
           operation={ApiMethodLabel(ListDapps.HTTP, ListDapps.Path)}
-          req={() => API.private.listDapps.resource()} />
+          resource={() => API.private.listDapps.resource()} />
       )
     }} />
   )

--- a/src/rootCmds/privateCmds/listDapps.tsx
+++ b/src/rootCmds/privateCmds/listDapps.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { App, PrettyRequest, ApiMethodLabel } from '../../ui';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender } from '../../services/util';
+import { requireAuthData, fastRender } from '../../services';
 import { ArgShape, UniversalArgs } from '../../cli';
 import { ListDapps } from '@eximchain/dappbot-types/spec/methods/private';
 

--- a/src/rootCmds/privateCmds/readDapp.tsx
+++ b/src/rootCmds/privateCmds/readDapp.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Argv } from 'yargs';
 import { App, PrettyRequest, ApiMethodLabel } from '../../ui';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender } from '../../services/util';
+import { requireAuthData, fastRender } from '../../services';
 import { ArgShape, DappNameArg, UniversalArgs } from '../../cli';
 import { ReadDapp } from '@eximchain/dappbot-types/spec/methods/private';
 

--- a/src/rootCmds/privateCmds/readDapp.tsx
+++ b/src/rootCmds/privateCmds/readDapp.tsx
@@ -26,7 +26,7 @@ export function handler(args: ArgShape<DappNameArg>) {
       return (
         <PrettyRequest 
           operation={ApiMethodLabel(ReadDapp.HTTP, ReadDapp.Path(DappName))}
-          req={() => API.private.readDapp.resource(DappName)} />
+          resource={() => API.private.readDapp.resource(DappName)} />
       )
     }} />
   )

--- a/src/rootCmds/privateCmds/updateDapp.tsx
+++ b/src/rootCmds/privateCmds/updateDapp.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Argv } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender, cleanExit, analytics, standardTrackProps } from '../../services/util';
-import { BaseOptions, GuardianURL } from './createDapp';
+import { requireAuthData, fastRender, analytics, standardTrackProps } from '../../services';
+import { BaseOptions } from './createDapp';
 import { UpdateDapp } from '@eximchain/dappbot-types/spec/methods/private';
 import { DappNameArg, ArgShape, UniversalArgs } from '../../cli';
 import { PrettyRequest, App, ApiMethodLabel, ErrorBox } from '../../ui';

--- a/src/rootCmds/privateCmds/updateDapp.tsx
+++ b/src/rootCmds/privateCmds/updateDapp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Argv } from 'yargs';
 import { RootResources } from '@eximchain/dappbot-types/spec/methods';
-import { requireAuthData, fastRender, cleanExit } from '../../services/util';
+import { requireAuthData, fastRender, cleanExit, analytics, standardTrackProps } from '../../services/util';
 import { BaseOptions, GuardianURL } from './createDapp';
 import { UpdateDapp } from '@eximchain/dappbot-types/spec/methods/private';
 import { DappNameArg, ArgShape, UniversalArgs } from '../../cli';
@@ -59,7 +59,15 @@ export function handler(args:ArgShape<UpdateDapp.Args & DappNameArg>) {
     <App args={args} renderFunc={({ API }) => (
       <PrettyRequest 
         operation={ApiMethodLabel(UpdateDapp.HTTP, UpdateDapp.Path(DappName))}
-        req={() => API.private.updateDapp.resource(DappName, updateArg)} />
+        resource={() => API.private.updateDapp.resource(DappName, updateArg)}
+        onSuccess={() => analytics.track({
+          event: 'Dapp Updated - CLI',
+          userId: API.authData.User.Email,
+          properties: {
+            ...standardTrackProps(API),
+            DappName, ...updateArg
+          }
+        })} />
     )} />
   )
 }

--- a/src/rootCmds/publicCmds/viewDapp.tsx
+++ b/src/rootCmds/publicCmds/viewDapp.tsx
@@ -27,7 +27,7 @@ export function handler(args: ArgShape<DappNameArg>) {
       return (
         <PrettyRequest  
           operation={ApiMethodLabel(ViewDapp.HTTP, ViewDapp.Path(DappName))} 
-          req={() => API.public.viewDapp.resource(DappName)} />
+          resource={() => API.public.viewDapp.resource(DappName)} />
       )
     }} />
   )

--- a/src/rootCmds/truffle.tsx
+++ b/src/rootCmds/truffle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
-import { fastRender, pathExists, cleanExit, isTruffleArtifact, TruffleArtifact, requireAuthData } from "../services/util";
+import { fastRender, pathExists, isTruffleArtifact, TruffleArtifact, requireAuthData } from "../services";
 import { App, TruffleFlow, ErrorBox } from "../ui";
 import { ArgShape, UniversalArgs } from "../cli";
 import { Argv } from 'yargs';

--- a/src/services/commandConfig.ts
+++ b/src/services/commandConfig.ts
@@ -1,0 +1,101 @@
+import { PositionalOptions, Argv, MiddlewareFunction } from "yargs";
+import fs from 'fs';
+import path from 'path';
+import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
+import User from "@eximchain/dappbot-types/spec/user";
+
+/**
+ * Given a desired command name and an example of the argument shape
+ * the command needs to output, return a yargs `command` string
+ * which includes all of the sample's keys as required arguments.
+ * @param command 
+ * @param sampleArg 
+ */
+export function commandFromSampleArgs(command:string, sampleArg:any) {
+  // Sorts arg names alphabetically, except for username, which
+  // always ought to be at the front of the list.
+  let args = Object.keys(sampleArg).sort();
+  if (args.includes('username')) {
+    args = ['username', ...args.filter(arg => arg !== 'username')]
+  }
+  // If this delimiter used [ ] instead of < >, the args would be
+  // marked as optional.
+  let delimiter = (name:string) => `<${name}>`;
+  return `${command} ${args.map(delimiter).join(' ')}`
+}
+
+type DescriptionMap<Shape> = Partial<Record<keyof Shape, string>>;
+
+/**
+ * Given a yargs instance, a sample argument shape, and a map of
+ * descriptions, call the `yargs.positional()` function with the
+ * appropriate args to instrument the command with help text for
+ * all arguments.  **Note**: This does not supported nested
+ * arguments; if a key's value type is not `string`, `number`, 
+ * or `boolean`, it is ignored.
+ * @param yargs 
+ * @param argShape 
+ * @param descriptions 
+ */
+export function describePositionalArgs<Shape extends object>(yargs:Argv, argShape:Shape, descriptions?:DescriptionMap<Shape>){
+  Object.keys(argShape).forEach((reqdKey) => {
+    let keyName = reqdKey as keyof Shape;
+    let keyType = typeof argShape[keyName];
+    if (
+      keyType === 'string' ||
+      keyType === 'number' ||
+      keyType === 'boolean'
+    ) {
+      let keyDesc = { type : keyType } as PositionalOptions;
+      if (descriptions && descriptions[keyName]) {
+        keyDesc.describe = descriptions[keyName]
+      }
+      yargs.positional(reqdKey, keyDesc)
+    }
+  })
+}
+
+/**
+ * Middlware: Listen for any options whose name ends in "Path", and if found,
+ * read the file's contents as a string and add it as an argument
+ * whose name ends in "File".  For instance, "authPath" will yield
+ * an "authFile" string, which can be JSON.parse()d to get the
+ * actual authData.
+ * @param args 
+ */
+export function loadFileFromPath(args:ArgShape): ArgShape {
+  const pathKeys = Object.keys(args).filter(key => key.indexOf('Path') > -1);
+  pathKeys.forEach(pathKey => {
+    const fullPath = path.resolve(process.cwd(), args[pathKey]);
+    if (!fs.existsSync(fullPath)) throw new Error(`The specified path (${pathKey}, ${args[pathKey]}) does not have a file!`);
+    const fileKey = `${pathKey.slice(0, pathKey.indexOf('Path'))}File`;
+    args[fileKey] = fs.readFileSync(fullPath).toString();
+  })
+  return args;
+}
+
+export function addDefaultConfigIfPresent(args:ArgShape): ArgShape {
+  if (args.config) return args;
+  const defaultPath = path.resolve(process.cwd(), DEFAULT_CONFIG_PATH);
+  if (!fs.existsSync(defaultPath)) return args;
+  Object.assign(args, JSON.parse(fs.readFileSync(defaultPath).toString()))
+  return args;
+}
+
+
+export function addDefaultAuthIfPresent(args:ArgShape): ArgShape {
+  if (args.authPath) return args;
+  const defaultPath = path.resolve(process.cwd(), DEFAULT_DATA_PATH);
+  if (!fs.existsSync(defaultPath)) return args;
+  args.authPath = defaultPath;
+  return args;
+}
+
+
+export const requireAuthData:MiddlewareFunction<UniversalArgs> = (args) => {
+  if (!args.authFile || !User.isAuthData(JSON.parse(args.authFile))) {
+    console.log("You're calling a private API method; please supply a path to your authData file with the --authPath option.");
+    process.exit(1);
+  }
+  return args;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,3 @@
+export * from './util';
+export * from './commandConfig';
+export * from './truffle';

--- a/src/services/truffle.ts
+++ b/src/services/truffle.ts
@@ -1,0 +1,45 @@
+import { MethodAbi } from "ethereum-types";
+
+/**
+ * These interfaces do not represent a full Truffle artifact,
+ * just the pieces which we'll be using.
+ */
+export interface TruffleArtifact {
+  contract_name: string
+  abi: MethodAbi[]
+  networks: NetworkMap
+}
+
+export interface NetworkMap {
+  [key:string] : {
+    address: string
+  }
+}
+
+
+function isObject(val:any) {
+  return val !== null && typeof val === 'object';
+}
+
+export function isTruffleArtifact(val:any): val is TruffleArtifact {
+  return (
+    isObject(val) &&
+    typeof val.contract_name === 'string' &&
+    Array.isArray(val.abi) &&
+    isNetworkMap(val.networks)
+  )
+}
+
+export function isNetworkMap(val:any): val is NetworkMap {
+  if (!isObject(val)) return false;
+  if (Object.keys(val).length === 0) return true;
+  return (
+    Object.keys(val).every(val => parseInt(val) !== NaN) &&
+    Object.values(val).every((networkVal:any) => {
+      return (
+        isObject(networkVal) &&
+        typeof networkVal.address === 'string'
+      )
+    })
+  )
+}

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -1,10 +1,8 @@
-import { Argv, PositionalOptions, MiddlewareFunction } from "yargs";
 import { render } from 'ink';
 import Analytics from 'analytics-node';
 import fs from 'fs';
 import path from 'path';
 import DappbotAPI from '@eximchain/dappbot-api-client';
-import User from '@eximchain/dappbot-types/spec/user';
 import { npmPackage } from "../cli";
 
 const WRITE_KEY = 'aMv7BUcQfCSy8XYMBgXYMdLMr8fkhI4a';

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -3,119 +3,26 @@ import { render } from 'ink';
 import Analytics from 'analytics-node';
 import fs from 'fs';
 import path from 'path';
-import { MethodAbi } from 'ethereum-types';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import User from '@eximchain/dappbot-types/spec/user';
-import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
+import { npmPackage } from "../cli";
 
 const WRITE_KEY = 'aMv7BUcQfCSy8XYMBgXYMdLMr8fkhI4a';
 export const analytics = new Analytics(WRITE_KEY, { flushAt: 1})
+
+export function standardTrackProps(API:DappbotAPI) {
+  return {
+    email: API.authData.User.Email,
+    apiUrl: API.dappbotUrl,
+    cliVersion: npmPackage.version as string
+  }
+}
 
 export const fastRender:typeof render = (tree) => {
   // @ts-ignore Types don't know about fastmode
   return render(tree, { experimental: true })
 }
-/**
- * Given a desired command name and an example of the argument shape
- * the command needs to output, return a yargs `command` string
- * which includes all of the sample's keys as required arguments.
- * @param command 
- * @param sampleArg 
- */
-export function commandFromSampleArgs(command:string, sampleArg:any) {
-  // Sorts arg names alphabetically, except for username, which
-  // always ought to be at the front of the list.
-  let args = Object.keys(sampleArg).sort();
-  if (args.includes('username')) {
-    args = ['username', ...args.filter(arg => arg !== 'username')]
-  }
-  // If this delimiter used [ ] instead of < >, the args would be
-  // marked as optional.
-  let delimiter = (name:string) => `<${name}>`;
-  return `${command} ${args.map(delimiter).join(' ')}`
-}
 
-type DescriptionMap<Shape> = Partial<Record<keyof Shape, string>>;
-
-/**
- * Given a yargs instance, a sample argument shape, and a map of
- * descriptions, call the `yargs.positional()` function with the
- * appropriate args to instrument the command with help text for
- * all arguments.  **Note**: This does not supported nested
- * arguments; if a key's value type is not `string`, `number`, 
- * or `boolean`, it is ignored.
- * @param yargs 
- * @param argShape 
- * @param descriptions 
- */
-export function describePositionalArgs<Shape extends object>(yargs:Argv, argShape:Shape, descriptions?:DescriptionMap<Shape>){
-  Object.keys(argShape).forEach((reqdKey) => {
-    let keyName = reqdKey as keyof Shape;
-    let keyType = typeof argShape[keyName];
-    if (
-      keyType === 'string' ||
-      keyType === 'number' ||
-      keyType === 'boolean'
-    ) {
-      let keyDesc = { type : keyType } as PositionalOptions;
-      if (descriptions && descriptions[keyName]) {
-        keyDesc.describe = descriptions[keyName]
-      }
-      yargs.positional(reqdKey, keyDesc)
-    }
-  })
-}
-
-/**
- * Middlware: Listen for any options whose name ends in "Path", and if found,
- * read the file's contents as a string and add it as an argument
- * whose name ends in "File".  For instance, "authPath" will yield
- * an "authFile" string, which can be JSON.parse()d to get the
- * actual authData.
- * @param args 
- */
-export function loadFileFromPath(args:ArgShape): ArgShape {
-  const pathKeys = Object.keys(args).filter(key => key.indexOf('Path') > -1);
-  pathKeys.forEach(pathKey => {
-    const fullPath = path.resolve(process.cwd(), args[pathKey]);
-    if (!fs.existsSync(fullPath)) throw new Error(`The specified path (${pathKey}, ${args[pathKey]}) does not have a file!`);
-    const fileKey = `${pathKey.slice(0, pathKey.indexOf('Path'))}File`;
-    args[fileKey] = fs.readFileSync(fullPath).toString();
-  })
-  return args;
-}
-
-export function addDefaultConfigIfPresent(args:ArgShape): ArgShape {
-  if (args.config) return args;
-  const defaultPath = path.resolve(process.cwd(), DEFAULT_CONFIG_PATH);
-  if (!fs.existsSync(defaultPath)) return args;
-  Object.assign(args, JSON.parse(fs.readFileSync(defaultPath).toString()))
-  return args;
-}
-
-
-export function addDefaultAuthIfPresent(args:ArgShape): ArgShape {
-  if (args.authPath) return args;
-  const defaultPath = path.resolve(process.cwd(), DEFAULT_DATA_PATH);
-  if (!fs.existsSync(defaultPath)) return args;
-  args.authPath = defaultPath;
-  return args;
-}
-
-
-export const requireAuthData:MiddlewareFunction<UniversalArgs> = (args) => {
-  if (!args.authFile || !User.isAuthData(JSON.parse(args.authFile))) {
-    console.log("You're calling a private API method; please supply a path to your authData file with the --authPath option.");
-    process.exit(1);
-  }
-  return args;
-}
-
-/**
- * POTENTIAL OPTIONS:
- * - Contract artifacts directory
- * 
- */
 
 export function cleanExit(message:string) {
   console.log(`\n${message}\n`)
@@ -141,54 +48,3 @@ export function pathExists(fileName:string|string[], dir:string):boolean {
   }
 }
 
-/**
- * These interfaces do not represent a full Truffle artifact,
- * just the pieces which we'll be using.
- */
-export interface TruffleArtifact {
-  contract_name: string
-  abi: MethodAbi[]
-  networks: NetworkMap
-}
-
-export interface NetworkMap {
-  [key:string] : {
-    address: string
-  }
-}
-
-
-function isObject(val:any) {
-  return val !== null && typeof val === 'object';
-}
-
-export function isTruffleArtifact(val:any): val is TruffleArtifact {
-  return (
-    isObject(val) &&
-    typeof val.contract_name === 'string' &&
-    Array.isArray(val.abi) &&
-    isNetworkMap(val.networks)
-  )
-}
-
-export function isNetworkMap(val:any): val is NetworkMap {
-  if (!isObject(val)) return false;
-  if (Object.keys(val).length === 0) return true;
-  return (
-    Object.keys(val).every(val => parseInt(val) !== NaN) &&
-    Object.values(val).every((networkVal:any) => {
-      return (
-        isObject(networkVal) &&
-        typeof networkVal.address === 'string'
-      )
-    })
-  )
-}
-
-export function standardTrackProps(API:DappbotAPI) {
-  return {
-    email: API.authData.User.Email,
-    apiUrl: API.dappbotUrl,
-    cliVersion: npmPackage.version as string
-  }
-}

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -4,8 +4,9 @@ import Analytics from 'analytics-node';
 import fs from 'fs';
 import path from 'path';
 import { MethodAbi } from 'ethereum-types';
+import DappbotAPI from '@eximchain/dappbot-api-client';
 import User from '@eximchain/dappbot-types/spec/user';
-import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs } from "../cli";
+import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
 
 const WRITE_KEY = 'aMv7BUcQfCSy8XYMBgXYMdLMr8fkhI4a';
 export const analytics = new Analytics(WRITE_KEY, { flushAt: 1})
@@ -182,4 +183,12 @@ export function isNetworkMap(val:any): val is NetworkMap {
       )
     })
   )
+}
+
+export function standardTrackProps(API:DappbotAPI) {
+  return {
+    email: API.authData.User.Email,
+    apiUrl: API.dappbotUrl,
+    cliVersion: npmPackage.version as string
+  }
 }

--- a/src/services/util.ts
+++ b/src/services/util.ts
@@ -1,12 +1,14 @@
 import { Argv, PositionalOptions, MiddlewareFunction } from "yargs";
 import { render } from 'ink';
+import Analytics from 'analytics-node';
 import fs from 'fs';
 import path from 'path';
-import User from '@eximchain/dappbot-types/spec/user';
 import { MethodAbi } from 'ethereum-types';
+import User from '@eximchain/dappbot-types/spec/user';
 import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs } from "../cli";
-import groupBy from 'lodash.groupby';
 
+const WRITE_KEY = 'aMv7BUcQfCSy8XYMBgXYMdLMr8fkhI4a';
+export const analytics = new Analytics(WRITE_KEY, { flushAt: 1})
 
 export const fastRender:typeof render = (tree) => {
   // @ts-ignore Types don't know about fastmode

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { newAuthData, AuthData } from '@eximchain/dappbot-types/spec/user';
-import { ArgShape, AdditionalArgs, npmPackage } from '../cli';
+import { ArgShape, AdditionalArgs } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
 import axios from 'axios';

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,7 +7,7 @@ import { ArgShape, AdditionalArgs, npmPackage } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
 import axios from 'axios';
-import { analytics } from '../services/util';
+import { analytics, standardTrackProps } from '../services/util';
 
 export type RenderFuncProps<Additional extends AdditionalArgs = AdditionalArgs> = (props: {
   API: DappbotAPI
@@ -38,14 +38,17 @@ function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<A
   })
 
   useEffect(function refreshIfStale() {
-    if (API.hasStaleAuth()) API.refreshAuth()
-    analytics.identify({
-      userId: authData.User.Email,
-      traits: {
-        cliVersion: npmPackage.version,
-        apiUrl: args.apiUrl
-      }
-    })
+    if (API.hasStaleAuth()) {
+      API.refreshAuth()
+      analytics.track({
+        userId: API.authData.User.Email,
+        event: 'User Login - CLI',
+        properties: {
+          ...standardTrackProps(API),
+          isRefresh: true
+        }
+      })
+    }
   }, [API, authData])
 
   return API.hasStaleAuth() ? (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,10 +3,11 @@ import path from 'path';
 import fs from 'fs';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { newAuthData, AuthData } from '@eximchain/dappbot-types/spec/user';
-import { ArgShape, AdditionalArgs } from '../cli';
+import { ArgShape, AdditionalArgs, npmPackage } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
 import axios from 'axios';
+import { analytics } from '../services/util';
 
 export type RenderFuncProps<Additional extends AdditionalArgs = AdditionalArgs> = (props: {
   API: DappbotAPI
@@ -38,6 +39,13 @@ function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<A
 
   useEffect(function refreshIfStale() {
     if (API.hasStaleAuth()) API.refreshAuth()
+    analytics.identify({
+      userId: authData.User.Email,
+      traits: {
+        cliVersion: npmPackage.version,
+        apiUrl: args.apiUrl
+      }
+    })
   }, [API, authData])
 
   return API.hasStaleAuth() ? (

--- a/src/ui/LoginFlow.tsx
+++ b/src/ui/LoginFlow.tsx
@@ -7,6 +7,7 @@ import ArgPrompt from './helpers/ArgPrompt';
 import Responses from '@eximchain/dappbot-types/spec/responses';
 import User from '@eximchain/dappbot-types/spec/user';
 import { Loader, errMsgFromResource, SuccessBox, ErrorBox, ChevronText } from './helpers';
+import { analytics } from '../services/util';
 import { DEFAULT_DATA_PATH } from '../cli';
 
 export interface LoginFlowProps {
@@ -26,6 +27,10 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       Responses.isSuccessResponse(data) &&
       User.isAuthData(data.data)
     ) {
+      analytics.track({
+        event: 'Successful CLI Login',
+        userId: data.data.User.Email
+      })
       const authData = data.data;
       const authPath = path.resolve(process.cwd(), dataPath);
       fs.writeFileSync(authPath, JSON.stringify(authData, null, 2));
@@ -72,6 +77,7 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
     let followonMsg = dataPath === DEFAULT_DATA_PATH ?
       `Your auth data will be automatically inferred from ${dataPath} for private commands.` :
       `Please include the authPath option (e.g. $ dappbot --authPath ${dataPath} ...) for private commands.`
+    
     return (
       <SuccessBox permanent result={{
         message: `You are now logged in! ${followonMsg}`

--- a/src/ui/LoginFlow.tsx
+++ b/src/ui/LoginFlow.tsx
@@ -7,7 +7,7 @@ import ArgPrompt from './helpers/ArgPrompt';
 import Responses from '@eximchain/dappbot-types/spec/responses';
 import User from '@eximchain/dappbot-types/spec/user';
 import { Loader, errMsgFromResource, SuccessBox, ErrorBox, ChevronText } from './helpers';
-import { analytics } from '../services/util';
+import { analytics, standardTrackProps } from '../services/util';
 import { DEFAULT_DATA_PATH } from '../cli';
 
 export interface LoginFlowProps {
@@ -28,11 +28,16 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       User.isAuthData(data.data)
     ) {
       analytics.track({
-        event: 'CLI Login',
-        userId: data.data.User.Email
-      })
-      analytics.identify({
-
+        event: 'User Login - CLI',
+        userId: data.data.User.Email,
+        properties: {
+          ...standardTrackProps(API),
+          // Manually setting email because we do not
+          // expect the API to already have valid auth
+          // within this flow.
+          email: data.data.User.Email,
+          isRefresh: false
+        }
       })
       const authData = data.data;
       const authPath = path.resolve(process.cwd(), dataPath);

--- a/src/ui/LoginFlow.tsx
+++ b/src/ui/LoginFlow.tsx
@@ -28,8 +28,11 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       User.isAuthData(data.data)
     ) {
       analytics.track({
-        event: 'Successful CLI Login',
+        event: 'CLI Login',
         userId: data.data.User.Email
+      })
+      analytics.identify({
+
       })
       const authData = data.data;
       const authPath = path.resolve(process.cwd(), dataPath);

--- a/src/ui/PrettyRequest.tsx
+++ b/src/ui/PrettyRequest.tsx
@@ -4,12 +4,12 @@ import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { Loader, ErrorBox, SuccessBox, errMsgFromResource } from './helpers';
 
 export interface PrettyRequestProps<ResponseType = any> {
-  req: () => Resource<ResponseType>
-  onComplete?: (response: ResponseType) => void
+  resource: () => Resource<ResponseType>
+  onSuccess?: (response: ResponseType) => void
   operation?: string
 }
 
-export const PrettyRequest: FC<PrettyRequestProps> = ({ req, onComplete, operation }) => {
+export const PrettyRequest: FC<PrettyRequestProps> = ({ resource: req, onSuccess: onComplete, operation }) => {
   const [response, request] = useResource(req);
   const { isLoading, data, error } = response;
 
@@ -18,7 +18,9 @@ export const PrettyRequest: FC<PrettyRequestProps> = ({ req, onComplete, operati
   }, [])
 
   useEffect(function handleSuccess() {
-    if (data && isSuccessResponse(data) && onComplete) onComplete(data.data);
+    if (isSuccessResponse(data) && onComplete) {
+      onComplete(data.data);
+    }
   }, [data])
 
   if (isLoading || (!data && !error)) {

--- a/src/ui/SignupFlow/Stage1-CreateAccount.tsx
+++ b/src/ui/SignupFlow/Stage1-CreateAccount.tsx
@@ -5,7 +5,6 @@ import { ArgPrompt, ErrorBox, Loader, ChevronText } from '../helpers';
 import { Payment } from '@eximchain/dappbot-types/spec/methods';
 import Responses from '@eximchain/dappbot-types/spec/responses';
 import { analytics, standardTrackProps } from '../../services/util';
-import { npmPackage } from '../../cli';
 
 export interface CreateAccountProps {
   API: DappbotAPI

--- a/src/ui/SignupFlow/Stage1-CreateAccount.tsx
+++ b/src/ui/SignupFlow/Stage1-CreateAccount.tsx
@@ -4,6 +4,8 @@ import { useResource } from 'react-request-hook';
 import { ArgPrompt, ErrorBox, Loader, ChevronText } from '../helpers';
 import { Payment } from '@eximchain/dappbot-types/spec/methods';
 import Responses from '@eximchain/dappbot-types/spec/responses';
+import { analytics, standardTrackProps } from '../../services/util';
+import { npmPackage } from '../../cli';
 
 export interface CreateAccountProps {
   API: DappbotAPI
@@ -20,6 +22,17 @@ export const CreateAccount: FC<CreateAccountProps> = ({ API, setEmail }) => {
   useEffect(function handleResponse() {
     if (Responses.isSuccessResponse(data)) {
       setEmail(email);
+      analytics.track({
+        event: 'User Signup - CLI',
+        userId: email,
+        properties: {
+          ...standardTrackProps(API),
+          // Manually setting email because we do not
+          // expect the API to have any valid auth
+          // within this flow.
+          email, name
+        }
+      })
     } else {
       setLocalErr(data);
     }

--- a/src/ui/SignupFlow/Stage2-InitialLogin.tsx
+++ b/src/ui/SignupFlow/Stage2-InitialLogin.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useEffect } from 'react';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { useResource } from 'react-request-hook';
-import { ArgPrompt, ErrorBox, Loader, Rows, ChevronText } from '../helpers';
+import { ArgPrompt, ErrorBox, Loader, ChevronText } from '../helpers';
 import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { Challenges } from '@eximchain/dappbot-types/spec/user';
 

--- a/src/ui/SignupFlow/Stage4-FinalLogin.tsx
+++ b/src/ui/SignupFlow/Stage4-FinalLogin.tsx
@@ -8,6 +8,7 @@ import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { isAuthData } from '@eximchain/dappbot-types/spec/user';
 import { DEFAULT_DATA_PATH } from '../../cli';
 import { Static, Box, Text } from 'ink';
+import { analytics, standardTrackProps } from '../../services/util';
 
 export interface StageFinalLoginProps {
   API: DappbotAPI
@@ -26,6 +27,18 @@ export const StageFinalLogin: FC<StageFinalLoginProps> = ({ API, email, pass }) 
     let authData = data.data;
     fs.writeFileSync(path.resolve(process.cwd(), authPath), JSON.stringify(authData, null, 2))
     setWriteComplete(true);
+    analytics.track({
+      event: 'User Login - CLI',
+      userId: authData.User.Email,
+      properties: {
+        ...standardTrackProps(API),
+        // Manually setting email because this API
+        // will not be configured with the new auth
+        // from this very login.
+        email: authData.User.Email,
+        isRefresh: false
+      }
+    })
   }, [isLoading, data, error, authPath])
 
   if (authPath === '') {

--- a/src/ui/SignupFlow/Stage4-FinalLogin.tsx
+++ b/src/ui/SignupFlow/Stage4-FinalLogin.tsx
@@ -3,11 +3,11 @@ import fs from 'fs';
 import path from 'path';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { useResource } from 'react-request-hook';
-import { ArgPrompt, ErrorBox, Loader, TextBox, ChevronText, Rows, SuccessBox, SuccessLabel } from '../helpers';
+import { ArgPrompt, ErrorBox, Loader, ChevronText, Rows, SuccessLabel } from '../helpers';
 import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { isAuthData } from '@eximchain/dappbot-types/spec/user';
 import { DEFAULT_DATA_PATH } from '../../cli';
-import { Static, Box, Text } from 'ink';
+import { Static, Text } from 'ink';
 import { analytics, standardTrackProps } from '../../services/util';
 
 export interface StageFinalLoginProps {

--- a/src/ui/TruffleFlow/Stage1-CreateOrUpdate.tsx
+++ b/src/ui/TruffleFlow/Stage1-CreateOrUpdate.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useEffect } from 'react';
-import { Text, Box } from 'ink';
+import { Text } from 'ink';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { useResource } from 'react-request-hook';
 import { ListDapps } from '@eximchain/dappbot-types/spec/methods/private';
@@ -9,7 +9,7 @@ import { XOR } from 'ts-xor';
 import Dapp from '@eximchain/dappbot-types/spec/dapp';
 import {
   Loader, ErrorBox, errMsgFromResource, ApiMethodLabel, SuccessBox,
-  Select, Rows, ChevronText
+  Select, ChevronText
 } from '../helpers';
 import { StringElt } from '.';
 import { Item } from 'ink-select-input';

--- a/src/ui/TruffleFlow/Stage2-SelectArtifact.tsx
+++ b/src/ui/TruffleFlow/Stage2-SelectArtifact.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { Text } from 'ink';
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact } from '../../services';
 import { Select, ChevronText } from '../helpers';
 import { StringElt } from '.';
 

--- a/src/ui/TruffleFlow/Stage3-SelectNetwork.tsx
+++ b/src/ui/TruffleFlow/Stage3-SelectNetwork.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import { Text } from 'ink';
 import flatten from 'lodash.flatten';
 import { ArgPrompt, ChainOption, ChevronText, Select } from '../helpers';
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact } from '../../services';
 import { XOR } from 'ts-xor';
 import { StringElt } from '.';
 import { Chain } from '@eximchain/dappbot-types/spec/dapp';

--- a/src/ui/TruffleFlow/Stage4-SetDappName.tsx
+++ b/src/ui/TruffleFlow/Stage4-SetDappName.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useEffect } from 'react';
 import { Text } from 'ink';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { Loader, ArgPrompt, Select, Rows, ChevronText } from '../helpers';
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact } from '../../services';
 import { useResource } from 'react-request-hook';
 import { StringElt } from '.';
 

--- a/src/ui/TruffleFlow/Stage5-ConfirmDapp.tsx
+++ b/src/ui/TruffleFlow/Stage5-ConfirmDapp.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Select, ChevronText, ItemList, ChainName } from '../helpers';
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact } from '../../services';
 import { Box } from 'ink';
 import { Chain } from '@eximchain/dappbot-types/spec/dapp';
 

--- a/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
+++ b/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
@@ -5,7 +5,7 @@ import {
   Loader, errMsgFromResource, ErrorBox, Rows, 
   ChevronText, SuccessLabel
 } from '../helpers';
-import { TruffleArtifact, analytics, standardTrackProps } from '../../services/util';
+import { TruffleArtifact, analytics, standardTrackProps } from '../../services';
 import { Tiers } from '@eximchain/dappbot-types/spec/dapp';
 import { useResource } from 'react-request-hook';
 import Responses from '@eximchain/dappbot-types/spec/responses';

--- a/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
+++ b/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
@@ -5,9 +5,10 @@ import {
   Loader, errMsgFromResource, ErrorBox, Rows, 
   ChevronText, SuccessLabel
 } from '../helpers';
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact, analytics } from '../../services/util';
 import { Tiers } from '@eximchain/dappbot-types/spec/dapp';
 import { useResource } from 'react-request-hook';
+import Responses from '@eximchain/dappbot-types/spec/responses';
 
 export interface StagePerformRequestProps {
   API: DappbotAPI
@@ -34,6 +35,20 @@ export const StagePerformRequest: FC<StagePerformRequestProps> = (props) => {
   useEffect(function callOnMount(){
     makeReq()
   }, [])
+
+  useEffect(function trackResponse(){
+    if (data && Responses.isSuccessResponse(data)) {
+      // if (isUpdate) {
+      //   analytics.track({
+
+      //   })
+      // } else {
+      //   analytics.track({
+
+      //   })
+      // }
+    }
+  }, [data]);
 
   // Second clause here handles the very first render
   // before the effect is triggered.

--- a/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
+++ b/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
@@ -5,7 +5,7 @@ import {
   Loader, errMsgFromResource, ErrorBox, Rows, 
   ChevronText, SuccessLabel
 } from '../helpers';
-import { TruffleArtifact, analytics } from '../../services/util';
+import { TruffleArtifact, analytics, standardTrackProps } from '../../services/util';
 import { Tiers } from '@eximchain/dappbot-types/spec/dapp';
 import { useResource } from 'react-request-hook';
 import Responses from '@eximchain/dappbot-types/spec/responses';
@@ -38,15 +38,27 @@ export const StagePerformRequest: FC<StagePerformRequestProps> = (props) => {
 
   useEffect(function trackResponse(){
     if (data && Responses.isSuccessResponse(data)) {
-      // if (isUpdate) {
-      //   analytics.track({
-
-      //   })
-      // } else {
-      //   analytics.track({
-
-      //   })
-      // }
+      if (isUpdate) {
+        analytics.track({
+          event: 'Dapp Updated - CLI - Truffle',
+          userId: API.authData.User.Email,
+          properties: {
+            ...standardTrackProps(API),
+            DappName, Web3URL, ContractAddr
+          }
+        })
+      } else {
+        analytics.track({
+          event: 'Dapp Created - CLI - Truffle',
+          userId: API.authData.User.Email,
+          properties: {
+            ...standardTrackProps(API),
+            Web3URL, ContractAddr, Abi,
+            GuardianURL: 'https://example.com',
+            Tier: Tiers.Standard
+          }
+        })
+      }
     }
   }, [data]);
 

--- a/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
+++ b/src/ui/TruffleFlow/Stage6-PerformRequest.tsx
@@ -40,7 +40,7 @@ export const StagePerformRequest: FC<StagePerformRequestProps> = (props) => {
     if (data && Responses.isSuccessResponse(data)) {
       if (isUpdate) {
         analytics.track({
-          event: 'Dapp Updated - CLI - Truffle',
+          event: 'Dapp Updated - CLI:Truffle',
           userId: API.authData.User.Email,
           properties: {
             ...standardTrackProps(API),
@@ -49,7 +49,7 @@ export const StagePerformRequest: FC<StagePerformRequestProps> = (props) => {
         })
       } else {
         analytics.track({
-          event: 'Dapp Created - CLI - Truffle',
+          event: 'Dapp Created - CLI:Truffle',
           userId: API.authData.User.Email,
           properties: {
             ...standardTrackProps(API),

--- a/src/ui/TruffleFlow/index.tsx
+++ b/src/ui/TruffleFlow/index.tsx
@@ -48,17 +48,6 @@ export const TruffleFlow:FC<TruffleFlowProps> = (props) => {
     setProgressMsgs([]);
   }
 
-  useEffect(function trackCall(){
-    const authData: User.AuthData = JSON.parse(authFile);
-    analytics.track({
-      userId: authData.User.Email,
-      event: 'CLI Truffle Flow',
-      properties: {
-        cliVersion: npmPackage.version
-      }
-    })
-  }, []);
-
   if (isUpdate === null) return (
     <CreateOrUpdate {...{ API, authFile, setIsUpdate, setDappName, addProgressMsg }} />
   )

--- a/src/ui/TruffleFlow/index.tsx
+++ b/src/ui/TruffleFlow/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useState } from 'react';
 import { TextProps } from 'ink';
 import { XOR } from 'ts-xor';
 import DappbotAPI from '@eximchain/dappbot-api-client';
@@ -11,8 +11,6 @@ import SelectNetwork from './Stage3-SelectNetwork';
 import SetDappName from './Stage4-SetDappName';
 import ConfirmDapp from './Stage5-ConfirmDapp';
 import PerformRequest from './Stage6-PerformRequest';
-import User from '@eximchain/dappbot-types/spec/user';
-import { npmPackage } from '../../cli';
 
 export interface TruffleFlowProps {
   API: DappbotAPI

--- a/src/ui/TruffleFlow/index.tsx
+++ b/src/ui/TruffleFlow/index.tsx
@@ -3,7 +3,7 @@ import { TextProps } from 'ink';
 import { XOR } from 'ts-xor';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 
-import { TruffleArtifact, analytics } from '../../services/util';
+import { TruffleArtifact } from '../../services';
 
 import CreateOrUpdate from './Stage1-CreateOrUpdate';
 import SelectArtifact from './Stage2-SelectArtifact';

--- a/src/ui/TruffleFlow/index.tsx
+++ b/src/ui/TruffleFlow/index.tsx
@@ -1,9 +1,9 @@
-import React, { FC, useState, ReactElement } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import { TextProps } from 'ink';
 import { XOR } from 'ts-xor';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 
-import { TruffleArtifact } from '../../services/util';
+import { TruffleArtifact, analytics } from '../../services/util';
 
 import CreateOrUpdate from './Stage1-CreateOrUpdate';
 import SelectArtifact from './Stage2-SelectArtifact';
@@ -11,6 +11,8 @@ import SelectNetwork from './Stage3-SelectNetwork';
 import SetDappName from './Stage4-SetDappName';
 import ConfirmDapp from './Stage5-ConfirmDapp';
 import PerformRequest from './Stage6-PerformRequest';
+import User from '@eximchain/dappbot-types/spec/user';
+import { npmPackage } from '../../cli';
 
 export interface TruffleFlowProps {
   API: DappbotAPI
@@ -22,6 +24,7 @@ export type StringElt = string | ReturnType<FC<TextProps>>;
 
 export const TruffleFlow:FC<TruffleFlowProps> = (props) => {
   const { API, artifacts, authFile } = props;
+  
   const [isUpdate, setIsUpdate] = useState(null as XOR<null, boolean>);
   const [artifact, setArtifact] = useState(null as XOR<null, TruffleArtifact>);
   const [Web3URL, setWeb3URL] = useState('');
@@ -44,6 +47,17 @@ export const TruffleFlow:FC<TruffleFlowProps> = (props) => {
     setDappName('');
     setProgressMsgs([]);
   }
+
+  useEffect(function trackCall(){
+    const authData: User.AuthData = JSON.parse(authFile);
+    analytics.track({
+      userId: authData.User.Email,
+      event: 'CLI Truffle Flow',
+      properties: {
+        cliVersion: npmPackage.version
+      }
+    })
+  }, []);
 
   if (isUpdate === null) return (
     <CreateOrUpdate {...{ API, authFile, setIsUpdate, setDappName, addProgressMsg }} />


### PR DESCRIPTION
This PR is now ready to go!  It covers all of the events listed in https://github.com/Eximchain/dappbot-api-lambda/issues/33

Conceptually, the chunks of work here are:
- Creating & configuring a valid `analytics-node` object
- Ensuring that all tracked calls are properly labeled by user
- Adding `.track()` calls at all of the required trigger locations