### PR TITLE
Added two more prompts in SignupFlow so we still collect metadata

### DIFF
--- a/src/ui/SignupFlow/Stage1-CreateAccount.tsx
+++ b/src/ui/SignupFlow/Stage1-CreateAccount.tsx
@@ -12,7 +12,6 @@ export interface CreateAccountProps {
 }
 
 export const CreateAccount: FC<CreateAccountProps> = ({ API, setEmail }) => {
-  // TODO: Gather organization & occupation
   const [email, setEmailState] = useState('');
   const [name, setName] = useState('');
   const [organization, setOrganization] = useState('');

--- a/src/ui/SignupFlow/Stage1-CreateAccount.tsx
+++ b/src/ui/SignupFlow/Stage1-CreateAccount.tsx
@@ -15,6 +15,8 @@ export const CreateAccount: FC<CreateAccountProps> = ({ API, setEmail }) => {
   // TODO: Gather organization & occupation
   const [email, setEmailState] = useState('');
   const [name, setName] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [occupation, setOccupation] = useState('');
 
   const [signupResponse, requestSignup] = useResource(API.payment.signUp.resource);
   const { data, isLoading, error } = signupResponse;
@@ -22,7 +24,7 @@ export const CreateAccount: FC<CreateAccountProps> = ({ API, setEmail }) => {
   useEffect(function handleResponse() {
     if (Responses.isSuccessResponse(data)) {
       setEmail(email);
-      trackSignup(API, email, { name });
+      trackSignup(API, email, { name, organization, occupation });
     } else {
       setLocalErr(data);
     }
@@ -40,13 +42,40 @@ export const CreateAccount: FC<CreateAccountProps> = ({ API, setEmail }) => {
       label={<ChevronText>What is your name?</ChevronText>}
       withResult={(nameVal) => {
         setName(nameVal);
+      }}
+      key='namePrompt' />
+  )
+
+  if (organization === '') return (
+    <ArgPrompt name='Organization'
+      label={[
+        <ChevronText key='org-q'>What organization are you working with?  If you're working alone, please enter "Self".</ChevronText>,
+        <ChevronText key='org-optional'>This is optional, but we are curious.</ChevronText>
+      ]}
+      withResult={(orgVal) => {
+        // This value needs to not be an empty string in order
+        // to progress within the flow.
+        let chosenVal = orgVal !== '' ? orgVal : 'N/A';
+        setOrganization(chosenVal);
+      }}
+      key='orgPrompt' />
+  )
+
+  if (occupation === '') return (
+    <ArgPrompt name='Occupation'
+      label={[
+        <ChevronText key='occupation-q'>What is your occupation?</ChevronText>,
+        <ChevronText key='occupation-optional'>This is also optional, although we are still curious.</ChevronText>
+      ]}
+      withResult={(occupationVal) => {
+        let chosenVal = occupationVal !== '' ? occupationVal : 'N/A';
+        setOccupation(chosenVal);
         requestSignup({
-          email,
-          name: nameVal,
+          email, name,
           plans: Payment.trialStripePlan()
         })
       }}
-      key='namePrompt' />
+      key='occupationPrompt' />
   )
 
   return error || localErr ? (


### PR DESCRIPTION
Pretty small PR, just added two more `ArgPrompt`s to Stage1 of the SignupFlow for `organization` and `occupation`.  Wanna get a second set of eyes on my prompt labels, but this has already been tested locally.  Here's how the organization prompt looks like:

![image](https://user-images.githubusercontent.com/3820981/67439009-15855c00-f5c3-11e9-9e85-d208466a8593.png)

Check out the resulting user doc in Amplitude, particularly the values at the bottom:

![image](https://user-images.githubusercontent.com/3820981/67438922-d3f4b100-f5c2-11e9-9f3d-c41a47cad2c9.png)

Edit: the `trackSignup()` method already handles assigning the metadata onto the Segment user, as shown here: https://github.com/Eximchain/dappbot-cli/blob/master/src/services/analytics.ts#L53