### PR TITLE
Auth at install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.1.8",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.1.8",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,15 @@
 				"@types/lodash": "*"
 			}
 		},
+		"@types/lodash.isequal": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
+			"integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			}
+		},
 		"@types/lodash.omit": {
 			"version": "4.5.6",
 			"resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.2.0",
+	"version": "0.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"scripts": {
 		"test": "xo && ava",
 		"build": "tsc",
+		"dev": "tsc --watch",
 		"start": "node build/cli.js",
 		"prepare": "npm run build",
 		"postinstall": "node build/cli.js onboarding"
@@ -47,6 +48,7 @@
 		"ink-text-input": "^3.2.1",
 		"lodash.flatten": "^4.4.0",
 		"lodash.groupby": "^4.6.0",
+		"lodash.isequal": "^4.5.0",
 		"node-fetch": "^2.6.0",
 		"open": "^6.4.0",
 		"password-validator": "^5.0.2",
@@ -59,6 +61,7 @@
 	"devDependencies": {
 		"@babel/preset-react": "^7.0.0",
 		"@babel/register": "^7.6.0",
+		"@types/lodash.isequal": "^4.5.5",
 		"ava": "^2.3.0",
 		"chalk": "^2.4.2",
 		"eslint-config-xo-react": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.1.8",
+	"version": "0.2.0",
 	"author": {
 		"name": "John O'Sullivan",
 		"email": "john@eximchain.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.1.8",
+	"version": "1.0.0",
 	"author": {
 		"name": "John O'Sullivan",
 		"email": "john@eximchain.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eximchain/dappbot-cli",
-	"version": "0.2.0",
+	"version": "0.1.8",
 	"author": {
 		"name": "John O'Sullivan",
 		"email": "john@eximchain.com"

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,7 +2,7 @@
 import yargs, { Arguments } from 'yargs';
 import fs from 'fs';
 import path from 'path';
-import { loadFileFromPath, addDefaultAuthIfPresent, addDefaultConfigIfPresent } from './services';
+import { loadFileFromPath, addDefaultAuthPath, addDefaultConfigFile } from './services';
 
 export const npmPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './../package.json')).toString());
 
@@ -32,7 +32,8 @@ yargs
 		authPath : {
 			alias: 'a',
 			normalize: true,
-			description: "The path to a JSON file with saved DappBot auth data; defaults to './dappbotAuthData.json'."
+			hidden: true,
+			description: `The path to a JSON file with saved DappBot auth data; defaults to ${__dirname}/dappbotAuthData.json.`
 		},
 		apiUrl: {
 			description: "The URL for DappBot's API.",
@@ -50,8 +51,8 @@ yargs
 			group: 'URL Options:'
 		}
 	})
-	.middleware(addDefaultAuthIfPresent)
-	.middleware(addDefaultConfigIfPresent)
+	.middleware(addDefaultAuthPath)
+	.middleware(addDefaultConfigFile)
 	.middleware(loadFileFromPath)
 	.commandDir('rootCmds')
 	.usage('Usage: dappbot <command>')

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -7,7 +7,6 @@ import { loadFileFromPath, addDefaultAuthPath, addDefaultConfigFile } from './se
 export const npmPackage = JSON.parse(fs.readFileSync(path.resolve(__dirname, './../package.json')).toString());
 
 export const DEFAULT_CONFIG_PATH = './dappbotConfig.json';
-export const DEFAULT_DATA_PATH = './dappbotAuthData.json';
 export interface DappNameArg {
   DappName: string
 }
@@ -56,7 +55,7 @@ yargs
 	.middleware(loadFileFromPath)
 	.commandDir('rootCmds')
 	.usage('Usage: dappbot <command>')
-	.demandCommand(2)
+	.demandCommand(1)
 	.wrap(Math.min(yargs.terminalWidth(), 160))
 	.help('help')
 	.alias('help', 'h')

--- a/src/rootCmds/truffle.tsx
+++ b/src/rootCmds/truffle.tsx
@@ -60,10 +60,6 @@ export function handler(args:ArgShape) {
     )
   }
 
-  // artifacts.forEach(artifact => console.log(Object.keys(artifact.networks)))
-  // console.log('now with parseInt')
-  // artifacts.forEach(artifact => console.log(Object.keys(artifact.networks).map(parseInt)))
-
   // Got deployable artifacts, good to go!
   fastRender(
     <App args={args} renderFunc={props => <TruffleFlow {...props} artifacts={deployedArtifacts} authFile={authFile}  />}/>

--- a/src/services/authStorage.ts
+++ b/src/services/authStorage.ts
@@ -4,13 +4,9 @@ import { AuthData, newAuthData } from '@eximchain/dappbot-types/spec/user';
 
 export const AUTH_DATA_PATH = path.resolve(__dirname, './dappbotAuthData.json');
 
-export function loadAuthFromFile():AuthData {
-  if (fs.existsSync(AUTH_DATA_PATH)) {
-    return JSON.parse(fs.readFileSync(AUTH_DATA_PATH).toString());
-  } else {
-    const freshAuth = newAuthData();
-    fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(freshAuth, null, 2));
-    return freshAuth;
+export function initAuthFile() {
+  if (!fs.existsSync(AUTH_DATA_PATH)) {
+    fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(newAuthData(), null, 2));
   }
 }
 

--- a/src/services/authStorage.ts
+++ b/src/services/authStorage.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import fs from 'fs';
+import { AuthData, newAuthData } from '@eximchain/dappbot-types/spec/user';
+
+export const AUTH_DATA_PATH = path.resolve(__dirname, './dappbotAuthData.json');
+
+export function loadAuthFromFile():AuthData {
+  if (fs.existsSync(AUTH_DATA_PATH)) {
+    return JSON.parse(fs.readFileSync(AUTH_DATA_PATH).toString());
+  } else {
+    const freshAuth = newAuthData();
+    fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(freshAuth, null, 2));
+    return freshAuth;
+  }
+}
+
+export function saveAuthToFile(newData:AuthData) {
+  fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(newData, null, 2));
+}

--- a/src/services/authStorage.ts
+++ b/src/services/authStorage.ts
@@ -2,14 +2,15 @@ import path from 'path';
 import fs from 'fs';
 import { AuthData, newAuthData } from '@eximchain/dappbot-types/spec/user';
 
-export const AUTH_DATA_PATH = path.resolve(__dirname, './dappbotAuthData.json');
+export const AUTH_FILENAME = 'dappbotAuthData.json';
+export const AUTH_FILE_PATH = path.resolve(__dirname, `./${AUTH_FILENAME}`);
 
 export function initAuthFile() {
-  if (!fs.existsSync(AUTH_DATA_PATH)) {
-    fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(newAuthData(), null, 2));
+  if (!fs.existsSync(AUTH_FILE_PATH)) {
+    fs.writeFileSync(AUTH_FILE_PATH, JSON.stringify(newAuthData(), null, 2));
   }
 }
 
 export function saveAuthToFile(newData:AuthData) {
-  fs.writeFileSync(AUTH_DATA_PATH, JSON.stringify(newData, null, 2));
+  fs.writeFileSync(AUTH_FILE_PATH, JSON.stringify(newData, null, 2));
 }

--- a/src/services/commandConfig.ts
+++ b/src/services/commandConfig.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
 import User from "@eximchain/dappbot-types/spec/user";
+import { loadAuthFromFile } from "./authStorage";
 
 /**
  * Given a desired command name and an example of the argument shape
@@ -74,8 +75,13 @@ export function loadFileFromPath(args:ArgShape): ArgShape {
   return args;
 }
 
-export function addDefaultConfigIfPresent(args:ArgShape): ArgShape {
+export function addDefaultConfigFile(args:ArgShape): ArgShape {
+  // If the user is manually providing the path to an auth file,
+  // let that override the default -- just return.
   if (args.config) return args;
+
+  // Check if there's a `dappbotConfig.json` file, 
+  // load its contents if so.
   const defaultPath = path.resolve(process.cwd(), DEFAULT_CONFIG_PATH);
   if (!fs.existsSync(defaultPath)) return args;
   Object.assign(args, JSON.parse(fs.readFileSync(defaultPath).toString()))
@@ -83,11 +89,17 @@ export function addDefaultConfigIfPresent(args:ArgShape): ArgShape {
 }
 
 
-export function addDefaultAuthIfPresent(args:ArgShape): ArgShape {
+export function addDefaultAuthPath(args:ArgShape): ArgShape {
+  // If the user is manually providing the path to an auth file,
+  // do not overwrite it -- just return.
   if (args.authPath) return args;
-  const defaultPath = path.resolve(process.cwd(), DEFAULT_DATA_PATH);
-  if (!fs.existsSync(defaultPath)) return args;
-  args.authPath = defaultPath;
+
+  // The load function will initialize the file if it isn't present,
+  // so this pre-load guarantees that it will be successfully loaded
+  // by the `loadFileFromPath` middleware.
+  loadAuthFromFile();
+
+  args.authPath = DEFAULT_DATA_PATH;
   return args;
 }
 

--- a/src/services/commandConfig.tsx
+++ b/src/services/commandConfig.tsx
@@ -6,7 +6,7 @@ import isEqual from 'lodash.isequal';
 import { render } from 'ink';
 import { ArgShape, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
 import User from "@eximchain/dappbot-types/spec/user";
-import { AUTH_DATA_PATH, initAuthFile } from "./authStorage";
+import { AUTH_FILE_PATH, initAuthFile } from "./authStorage";
 import { ErrorBox } from '../ui';
 
 /**
@@ -103,7 +103,7 @@ export function addDefaultAuthPath(args:ArgShape): ArgShape {
   // by the `loadFileFromPath` middleware.
   initAuthFile();
 
-  args.authPath = AUTH_DATA_PATH;
+  args.authPath = AUTH_FILE_PATH;
   return args;
 }
 

--- a/src/services/commandConfig.tsx
+++ b/src/services/commandConfig.tsx
@@ -6,8 +6,7 @@ import isEqual from 'lodash.isequal';
 import { render } from 'ink';
 import { ArgShape, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
 import User from "@eximchain/dappbot-types/spec/user";
-import { loadAuthFromFile, AUTH_DATA_PATH } from "./authStorage";
-import { cleanExit } from "./util";
+import { AUTH_DATA_PATH, initAuthFile } from "./authStorage";
 import { ErrorBox } from '../ui';
 
 /**
@@ -102,7 +101,7 @@ export function addDefaultAuthPath(args:ArgShape): ArgShape {
   // The load function will initialize the file if it isn't present,
   // so this pre-load guarantees that it will be successfully loaded
   // by the `loadFileFromPath` middleware.
-  loadAuthFromFile();
+  initAuthFile();
 
   args.authPath = AUTH_DATA_PATH;
   return args;

--- a/src/services/commandConfig.tsx
+++ b/src/services/commandConfig.tsx
@@ -1,9 +1,14 @@
+import React from 'react';
 import { PositionalOptions, Argv, MiddlewareFunction } from "yargs";
 import fs from 'fs';
 import path from 'path';
-import { ArgShape, DEFAULT_DATA_PATH, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
+import isEqual from 'lodash.isequal';
+import { render } from 'ink';
+import { ArgShape, DEFAULT_CONFIG_PATH, UniversalArgs, npmPackage } from "../cli";
 import User from "@eximchain/dappbot-types/spec/user";
-import { loadAuthFromFile } from "./authStorage";
+import { loadAuthFromFile, AUTH_DATA_PATH } from "./authStorage";
+import { cleanExit } from "./util";
+import { ErrorBox } from '../ui';
 
 /**
  * Given a desired command name and an example of the argument shape
@@ -99,15 +104,32 @@ export function addDefaultAuthPath(args:ArgShape): ArgShape {
   // by the `loadFileFromPath` middleware.
   loadAuthFromFile();
 
-  args.authPath = DEFAULT_DATA_PATH;
+  args.authPath = AUTH_DATA_PATH;
   return args;
 }
 
 
 export const requireAuthData:MiddlewareFunction<UniversalArgs> = (args) => {
-  if (!args.authFile || !User.isAuthData(JSON.parse(args.authFile))) {
-    console.log("You're calling a private API method; please supply a path to your authData file with the --authPath option.");
+  function authErr() {
+    render(
+      <ErrorBox errMsg={"This command requires you to log in; please call 'dappbot signup' or 'dappbot login'."} />
+    )
     process.exit(1);
+  }
+  if (!args.authFile) {
+    authErr();
+    return;
+  }
+  const authData = JSON.parse(args.authFile);
+  if (!User.isAuthData(authData)) {
+    authErr();
+    return;
+  }
+  const { ExpiresAt, ...authDataMinusExpires } = authData;
+  const { ExpiresAt: OtherExpires, ...freshDataMinusExpires } = User.newAuthData();
+  if (isEqual(authDataMinusExpires, freshDataMinusExpires)) {
+    authErr()
+    return;
   }
   return args;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './util';
 export * from './commandConfig';
 export * from './truffle';
 export * from './analytics';
+export * from './authStorage';

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,8 +1,6 @@
 import React, { useState, PropsWithChildren, ReactElement, useEffect } from 'react';
-import path from 'path';
-import fs from 'fs';
 import DappbotAPI from '@eximchain/dappbot-api-client';
-import { newAuthData, AuthData } from '@eximchain/dappbot-types/spec/user';
+import { AuthData } from '@eximchain/dappbot-types/spec/user';
 import { ArgShape, AdditionalArgs } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
@@ -20,6 +18,16 @@ export type AppProps<Additional extends AdditionalArgs> = PropsWithChildren<{
   args: ArgShape<Additional>
   renderFunc: RenderFuncProps<Additional>
 }>
+
+export default App;
+
+export function App<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
+  return (
+    <RequestProvider value={axios}>
+      <AppWithoutProvider {...props} />
+    </RequestProvider>
+  )
+}
 
 function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
   const { args, renderFunc } = props;
@@ -49,13 +57,3 @@ function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<A
       })
     )
 }
-
-export function App<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
-  return (
-    <RequestProvider value={axios}>
-      <AppWithoutProvider {...props} />
-    </RequestProvider>
-  )
-}
-
-export default App;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,12 @@ export type AppProps<Additional extends AdditionalArgs> = PropsWithChildren<{
 
 export default App;
 
+/**
+ * App essentially just includes the <RequestProvider>, as we need it to have
+ * been rendered by a parent component in order to perform API calls via 
+ * the `.resource()` methods.
+ * @param props 
+ */
 export function App<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
   return (
     <RequestProvider value={axios}>
@@ -29,6 +35,11 @@ export function App<Additional extends AdditionalArgs>(props: AppProps<Additiona
   )
 }
 
+/**
+ * AppWithoutProvider performs the actual setup logic, including creating the
+ * API instance and refreshing the current authentication if necessary & possible.
+ * @param props 
+ */
 function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
   const { args, renderFunc } = props;
   const [authData, setAuthData] = useState(JSON.parse(args.authFile as string));

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,7 +7,7 @@ import { ArgShape, AdditionalArgs } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
 import axios from 'axios';
-import { trackLogin, saveAuthToFile, loadAuthFromFile } from '../services';
+import { trackLogin, saveAuthToFile } from '../services';
 
 export type RenderFuncProps<Additional extends AdditionalArgs = AdditionalArgs> = (props: {
   API: DappbotAPI
@@ -23,7 +23,7 @@ export type AppProps<Additional extends AdditionalArgs> = PropsWithChildren<{
 
 function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
   const { args, renderFunc } = props;
-  const [authData, setAuthData] = useState(loadAuthFromFile());
+  const [authData, setAuthData] = useState(JSON.parse(args.authFile as string));
 
   const API = new DappbotAPI({
     authData,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,7 +7,7 @@ import { ArgShape, AdditionalArgs } from '../cli';
 import { Loader } from './helpers';
 import { RequestProvider } from 'react-request-hook';
 import axios from 'axios';
-import { trackLogin } from '../services';
+import { trackLogin, saveAuthToFile, loadAuthFromFile } from '../services';
 
 export type RenderFuncProps<Additional extends AdditionalArgs = AdditionalArgs> = (props: {
   API: DappbotAPI
@@ -23,16 +23,13 @@ export type AppProps<Additional extends AdditionalArgs> = PropsWithChildren<{
 
 function AppWithoutProvider<Additional extends AdditionalArgs>(props: AppProps<Additional>): ReactElement {
   const { args, renderFunc } = props;
-  const initialAuth: AuthData = args.authFile ? JSON.parse(args.authFile) : newAuthData();
-  const [authData, setAuthData] = useState(initialAuth);
+  const [authData, setAuthData] = useState(loadAuthFromFile());
 
   const API = new DappbotAPI({
     authData,
     setAuthData: (auth) => {
-      if (args.authPath) {
-        fs.writeFileSync(path.resolve(process.cwd(), args.authPath), JSON.stringify(auth, null, 2));
-      }
       setAuthData(auth);
+      saveAuthToFile(auth);
     },
     dappbotUrl: args.apiUrl
   })

--- a/src/ui/LoginFlow.tsx
+++ b/src/ui/LoginFlow.tsx
@@ -7,7 +7,6 @@ import ArgPrompt from './helpers/ArgPrompt';
 import Responses from '@eximchain/dappbot-types/spec/responses';
 import User from '@eximchain/dappbot-types/spec/user';
 import { Loader, errMsgFromResource, SuccessBox, ErrorBox, ChevronText } from './helpers';
-import { DEFAULT_DATA_PATH } from '../cli';
 import { trackLogin, saveAuthToFile } from '../services';
 
 export interface LoginFlowProps {

--- a/src/ui/LoginFlow.tsx
+++ b/src/ui/LoginFlow.tsx
@@ -8,7 +8,7 @@ import Responses from '@eximchain/dappbot-types/spec/responses';
 import User from '@eximchain/dappbot-types/spec/user';
 import { Loader, errMsgFromResource, SuccessBox, ErrorBox, ChevronText } from './helpers';
 import { DEFAULT_DATA_PATH } from '../cli';
-import { trackLogin } from '../services';
+import { trackLogin, saveAuthToFile } from '../services';
 
 export interface LoginFlowProps {
   API: DappbotAPI
@@ -17,7 +17,6 @@ export interface LoginFlowProps {
 export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [dataPath, setDataPath] = useState(DEFAULT_DATA_PATH);
   const [loginResult, requestLogin] = useResource(API.auth.login.resource);
   const { data, isLoading, error } = loginResult;
 
@@ -27,12 +26,10 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       Responses.isSuccessResponse(data) &&
       User.isAuthData(data.data)
     ) {
+      saveAuthToFile(data.data)
       trackLogin(API, false);
-      const authData = data.data;
-      const authPath = path.resolve(process.cwd(), dataPath);
-      fs.writeFileSync(authPath, JSON.stringify(authData, null, 2));
     }
-  }, [data, dataPath])
+  }, [data])
 
   let credentialsLabel = <ChevronText>Please enter your login credentials.</ChevronText>;
   if (username === '') {
@@ -47,22 +44,12 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       <ArgPrompt name='password' hideVal
         label={credentialsLabel}
         key='passwordPrompt'
-        withResult={setPassword} />
-    )
-  } else if (!isLoading && !data && !error) {
-    return (
-      <ArgPrompt name='Path for auth data'
-        defaultValue={DEFAULT_DATA_PATH}
-        isValid={val => val.endsWith('.json') ? null : 'Path must end in .json'}
-        label={
-          <ChevronText>Where would you like to keep your authData file?  If you put it in the default location, DappBot will automatically read it without having to provide an option.</ChevronText>
-        }
         withResult={(val) => {
-          setDataPath(val);
-          requestLogin({ username, password })
+          requestLogin({ username, password: val });
+          setPassword(val)
         }} />
     )
-  } else if (isLoading) {
+  } else if (isLoading || (!data && !error)) {
     return (
       <Loader message={"Logging you into DappBot..."} />
     )
@@ -71,13 +58,9 @@ export const LoginFlow: FC<LoginFlowProps> = ({ API }) => {
       <ErrorBox errMsg={errMsgFromResource(error)} permanent />
     )
   } else {
-    let followonMsg = dataPath === DEFAULT_DATA_PATH ?
-      `Your auth data will be automatically inferred from ${dataPath} for private commands.` :
-      `Please include the authPath option (e.g. $ dappbot --authPath ${dataPath} ...) for private commands.`
-    
     return (
       <SuccessBox permanent result={{
-        message: `You are now logged in! ${followonMsg}`
+        message: `You are now logged in!`
       }} />
     )
   }

--- a/src/ui/SignupFlow/Stage4-FinalLogin.tsx
+++ b/src/ui/SignupFlow/Stage4-FinalLogin.tsx
@@ -8,7 +8,7 @@ import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { isAuthData } from '@eximchain/dappbot-types/spec/user';
 import { DEFAULT_DATA_PATH } from '../../cli';
 import { Static, Text } from 'ink';
-import { trackLogin } from '../../services';
+import { trackLogin, saveAuthToFile } from '../../services';
 
 export interface StageFinalLoginProps {
   API: DappbotAPI
@@ -22,31 +22,20 @@ export const StageFinalLogin: FC<StageFinalLoginProps> = ({ API, email, pass }) 
   const { isLoading, data, error } = loginResponse;
   const [writeComplete, setWriteComplete] = useState(false);
 
+  useEffect(function requestLoginOnLoad(){
+    requestLogin({
+      username: email,
+      password: pass
+    })
+  }, [])
+
   useEffect(function handleResponse(){
     if (!(isSuccessResponse(data) && isAuthData(data.data))) return;
     let authData = data.data;
-    fs.writeFileSync(path.resolve(process.cwd(), authPath), JSON.stringify(authData, null, 2))
+    saveAuthToFile(authData);
     setWriteComplete(true);
     trackLogin(API, false);
   }, [isLoading, data, error, authPath])
-
-  if (authPath === '') {
-    return (
-      <ArgPrompt name='Path for authData'
-        label={<ChevronText>Which file would you like to keep your authData in?  If you put it in the default location, DappBot will automatically read it without having to provide an option.</ChevronText>}
-        defaultValue={DEFAULT_DATA_PATH}
-        isValid={(val) => {
-          return val.endsWith('.json') ? null : 'Path must end in .json'
-        }}
-        withResult={(val) => {
-          setAuthPath(path.normalize(val)) 
-          requestLogin({
-            username: email,
-            password: pass
-          })
-        }} />
-    )
-  }
 
   if (error) return (
     <ErrorBox permanent errMsg={error.data.err.message} />

--- a/src/ui/SignupFlow/Stage4-FinalLogin.tsx
+++ b/src/ui/SignupFlow/Stage4-FinalLogin.tsx
@@ -6,7 +6,6 @@ import { useResource } from 'react-request-hook';
 import { ArgPrompt, ErrorBox, Loader, ChevronText, Rows, SuccessLabel } from '../helpers';
 import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { isAuthData } from '@eximchain/dappbot-types/spec/user';
-import { DEFAULT_DATA_PATH } from '../../cli';
 import { Static, Text } from 'ink';
 import { trackLogin, saveAuthToFile } from '../../services';
 
@@ -17,7 +16,6 @@ export interface StageFinalLoginProps {
 }
 
 export const StageFinalLogin: FC<StageFinalLoginProps> = ({ API, email, pass }) => {
-  const [authPath, setAuthPath] = useState('');
   const [loginResponse, requestLogin] = useResource(API.auth.login.resource);
   const { isLoading, data, error } = loginResponse;
   const [writeComplete, setWriteComplete] = useState(false);
@@ -35,7 +33,7 @@ export const StageFinalLogin: FC<StageFinalLoginProps> = ({ API, email, pass }) 
     saveAuthToFile(authData);
     setWriteComplete(true);
     trackLogin(API, false);
-  }, [isLoading, data, error, authPath])
+  }, [isLoading, data, error])
 
   if (error) return (
     <ErrorBox permanent errMsg={error.data.err.message} />
@@ -61,7 +59,7 @@ export const StageFinalLogin: FC<StageFinalLoginProps> = ({ API, email, pass }) 
       <></>
     </Static>
   ) : (
-    <Loader message={`Completing your login and saving the auth data to ${path.normalize(authPath)} ...`} />
+    <Loader message={`Completing your login...`} />
   )
 }
 


### PR DESCRIPTION
This PR upgrades the CLI by making it manage the `authFile` internally.  The first implementation asked the user where they wanted to keep it with respect to the working directory.  Now we keep it alongside the `authStorage.ts` file in `build/services` -- wherever the package is installed.  This way, your authentication is preserved no matter what your working directory is.