### PR TITLE
Very minor commit, just upgrading our underlying types & client packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -430,45 +430,34 @@
 				"arrify": "^1.0.1"
 			}
 		},
+		"@eximchain/api-types": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@eximchain/api-types/-/api-types-1.0.1.tgz",
+			"integrity": "sha512-QO56ZAORrxUjSClT+460GQJapn2TyDB5FG+RnaZ35hOsjGhr5IrQjcEyWduer+0Iqzaq7wX21y1k911MhHJGEg=="
+		},
 		"@eximchain/dappbot-api-client": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-api-client/-/dappbot-api-client-1.2.3.tgz",
-			"integrity": "sha512-cOoVx7TseCBdkLpnUDvuHzbW7XdZYccVGGeprTOt8LRwiGKy7oidQzJ3lwTaAwGh5wBOZtPsCVjGso21o1ihsQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-api-client/-/dappbot-api-client-1.2.5.tgz",
+			"integrity": "sha512-wZyc5ClwBZ0jppzUDj1RPDzlaNQ6zzf1JN2zMmu3LNoiZVt4Q869YZnAjRob6Jb7wlKdNtWfrLvmY3xQeo/2qA==",
 			"requires": {
-				"@eximchain/dappbot-types": "^1.7.8",
-				"@types/axios": "^0.14.0",
-				"@types/lodash.omit": "^4.5.6",
-				"@types/node": "^12.7.10",
-				"@types/node-fetch": "^2.5.0",
-				"@types/react": "^16.9.2",
-				"@types/request-promise-native": "^1.0.16",
+				"@eximchain/dappbot-types": "^1.7.13",
 				"ethereum-types": "^2.1.2",
 				"lodash.omit": "^4.5.0",
 				"node-fetch": "^2.6.0",
 				"password-validator": "^5.0.2",
 				"react-request-hook": "^2.1.1",
 				"request": "^2.88.0",
-				"request-promise-native": "^1.0.7",
-				"typescript": "^3.5.2"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.11.1",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
-					"integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A=="
-				}
+				"request-promise-native": "^1.0.7"
 			}
 		},
 		"@eximchain/dappbot-types": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-types/-/dappbot-types-1.7.8.tgz",
-			"integrity": "sha512-QI3FnQRf4m+NKIiOAjI2EVWCjgbZ36lTBYxoLFfnJJsIgzMjlYRiHNl6mU8S0HOlfnbooGDv2+J3ziG4bBvjpA==",
+			"version": "1.7.13",
+			"resolved": "https://registry.npmjs.org/@eximchain/dappbot-types/-/dappbot-types-1.7.13.tgz",
+			"integrity": "sha512-baU2Ls3/SzRW4Lt6vVdeIW77FZdtGtc6svqzMRRTEq7nvugJ3W3SZslvjy4B03g/xFNqFL6fzMcDUCmb9OqCwg==",
 			"requires": {
-				"@types/lodash.groupby": "^4.6.6",
-				"@types/stripe": "6.31.25",
-				"lodash.groupby": "^4.6.0",
-				"ts-xor": "^1.0.8",
-				"typescript": "^3.6.2"
+				"@eximchain/api-types": "^1.0.1",
+				"@types/stripe": "^6.32.13",
+				"ts-xor": "^1.0.8"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -536,19 +525,6 @@
 			"resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.1.tgz",
 			"integrity": "sha512-+Jrl6aQIV2uSy60DBSXflPt3+nTf/IxTVDM1gw5PhPhFi/STPDUlyiUp+zrmcEiiLQ7Y2R4jhrcQ6BcqAOclzg=="
 		},
-		"@types/axios": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-			"requires": {
-				"axios": "*"
-			}
-		},
-		"@types/caseless": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-		},
 		"@types/cli-spinners": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@types/cli-spinners/-/cli-spinners-1.3.0.tgz",
@@ -609,14 +585,6 @@
 				"@types/lodash": "*"
 			}
 		},
-		"@types/lodash.omit": {
-			"version": "4.5.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.6.tgz",
-			"integrity": "sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==",
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -626,14 +594,6 @@
 			"version": "12.7.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
 			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
-		},
-		"@types/node-fetch": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
-			"integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
-			"requires": {
-				"@types/node": "*"
-			}
 		},
 		"@types/prop-types": {
 			"version": "15.7.2",
@@ -649,25 +609,6 @@
 				"csstype": "^2.2.0"
 			}
 		},
-		"@types/request": {
-			"version": "2.48.3",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
-			"integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
-			"requires": {
-				"@types/caseless": "*",
-				"@types/node": "*",
-				"@types/tough-cookie": "*",
-				"form-data": "^2.5.0"
-			}
-		},
-		"@types/request-promise-native": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.17.tgz",
-			"integrity": "sha512-05/d0WbmuwjtGMYEdHIBZ0tqMJJQ2AD9LG2F6rKNBGX1SSFR27XveajH//2N/XYtual8T9Axwl+4v7oBtPUZqg==",
-			"requires": {
-				"@types/request": "*"
-			}
-		},
 		"@types/shelljs": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
@@ -678,17 +619,12 @@
 			}
 		},
 		"@types/stripe": {
-			"version": "6.31.25",
-			"resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-6.31.25.tgz",
-			"integrity": "sha512-e3MSNfOQp+8c/dR4Io52jzoJFnKLL0k6J9vEAFownNZt6OSqTMAeGFrWo5FEvW42CrJuQ52e3gv2w9TGN4nYrw==",
+			"version": "6.32.13",
+			"resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-6.32.13.tgz",
+			"integrity": "sha512-qMcM3ecF/4a0dtfMN2rm1w5TjSDzUqIIADI7BwXpkSUdXfekc4JjL2s7oAp9htB44nPsTYw5mxCCz9j1zTAXwA==",
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/tough-cookie": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-			"integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
 		},
 		"@types/yargs": {
 			"version": "13.0.2",
@@ -3499,16 +3435,6 @@
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
-		"form-data": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -6225,19 +6151,19 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.15"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
 			"requires": {
-				"request-promise-core": "1.1.2",
+				"request-promise-core": "1.1.3",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
@@ -7199,7 +7125,8 @@
 		"typescript": {
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
+			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+			"dev": true
 		},
 		"uid2": {
 			"version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 		"postinstall": "node build/cli.js onboarding"
 	},
 	"dependencies": {
-		"@eximchain/dappbot-api-client": "^1.2.3",
-		"@eximchain/dappbot-types": "^1.7.8",
+		"@eximchain/dappbot-api-client": "^1.2.5",
+		"@eximchain/dappbot-types": "^1.7.13",
 		"@types/analytics-node": "^3.1.1",
 		"@types/ink-spinner": "^2.0.1",
 		"@types/lodash.flatten": "^4.4.6",

--- a/src/ui/SignupFlow/Stage4-FinalLogin.tsx
+++ b/src/ui/SignupFlow/Stage4-FinalLogin.tsx
@@ -1,9 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
-import fs from 'fs';
-import path from 'path';
 import DappbotAPI from '@eximchain/dappbot-api-client';
 import { useResource } from 'react-request-hook';
-import { ArgPrompt, ErrorBox, Loader, ChevronText, Rows, SuccessLabel } from '../helpers';
+import { ErrorBox, Loader, ChevronText, Rows, SuccessLabel } from '../helpers';
 import { isSuccessResponse } from '@eximchain/dappbot-types/spec/responses';
 import { isAuthData } from '@eximchain/dappbot-types/spec/user';
 import { Static, Text } from 'ink';


### PR DESCRIPTION
This just bumps the underlying versions for `@eximchain/dappbot-types` and `@eximchain/dappbot-api-client` -- neither of those upgrades include any breaking changes, so there are no changes in usage.  Only file change here was removing unused imports.